### PR TITLE
Add internationalization to contact page hero section

### DIFF
--- a/app/contato/page.tsx
+++ b/app/contato/page.tsx
@@ -139,13 +139,7 @@ export default function ContactPage() {
                   className="max-w-4xl mx-auto mb-12"
                 >
                   <p className="text-xl md:text-2xl text-gray-600 leading-relaxed mb-6">
-                    Nosso time de especialistas está esperando por você!
-                    <strong className="text-[#1F2E5C]">
-                      {" "}
-                      Vamos descobrir juntos
-                    </strong>{" "}
-                    como transformar sua situação de crédito em uma história de
-                    sucesso.
+                    {t.contactPage.hero.subtitle}
                   </p>
 
                   {/* Quick Stats */}

--- a/app/contato/page.tsx
+++ b/app/contato/page.tsx
@@ -34,6 +34,9 @@ const staggerContainer = {
 };
 
 export default function ContactPage() {
+  const { language } = useLanguage();
+  const t = translations[language];
+
   return (
     <PageLayout>
       <div className="min-h-screen bg-white">

--- a/app/contato/page.tsx
+++ b/app/contato/page.tsx
@@ -125,9 +125,9 @@ export default function ContactPage() {
                   transition={{ duration: 0.8, delay: 0.4 }}
                   className="text-5xl md:text-6xl lg:text-7xl font-bold text-[#1F2E5C] leading-tight mb-6"
                 >
-                  Vamos Conversar?
+                  {t.contactPage.hero.title.split("\n")[0]}
                   <span className="block text-2xl md:text-3xl lg:text-4xl text-[#D86C1F] font-medium mt-4">
-                    Sua jornada financeira começa aqui 🚀
+                    {t.contactPage.hero.title.split("\n")[1]}
                   </span>
                 </motion.h1>
 

--- a/app/contato/page.tsx
+++ b/app/contato/page.tsx
@@ -113,7 +113,7 @@ export default function ContactPage() {
                       className="w-3 h-3 bg-white rounded-full"
                     ></motion.div>
                     <span className="font-semibold text-sm">
-                      ESTAMOS ONLINE E PRONTOS PARA AJUDAR
+                      {t.contactPage.hero.badge}
                     </span>
                   </div>
                 </motion.div>

--- a/app/contato/page.tsx
+++ b/app/contato/page.tsx
@@ -144,45 +144,26 @@ export default function ContactPage() {
 
                   {/* Quick Stats */}
                   <div className="flex flex-wrap justify-center gap-8 text-center">
-                    <motion.div
-                      initial={{ opacity: 0, scale: 0.8 }}
-                      animate={{ opacity: 1, scale: 1 }}
-                      transition={{ duration: 0.6, delay: 0.8 }}
-                      className="flex items-center gap-3"
-                    >
-                      <div className="w-8 h-8 bg-[#4CAF50] rounded-full flex items-center justify-center">
-                        <span className="text-white text-sm font-bold">✓</span>
-                      </div>
-                      <span className="text-gray-700 font-medium">
-                        Resposta em 24h
-                      </span>
-                    </motion.div>
-                    <motion.div
-                      initial={{ opacity: 0, scale: 0.8 }}
-                      animate={{ opacity: 1, scale: 1 }}
-                      transition={{ duration: 0.6, delay: 1 }}
-                      className="flex items-center gap-3"
-                    >
-                      <div className="w-8 h-8 bg-[#D86C1F] rounded-full flex items-center justify-center">
-                        <span className="text-white text-sm font-bold">💬</span>
-                      </div>
-                      <span className="text-gray-700 font-medium">
-                        Atendimento humanizado
-                      </span>
-                    </motion.div>
-                    <motion.div
-                      initial={{ opacity: 0, scale: 0.8 }}
-                      animate={{ opacity: 1, scale: 1 }}
-                      transition={{ duration: 0.6, delay: 1.2 }}
-                      className="flex items-center gap-3"
-                    >
-                      <div className="w-8 h-8 bg-[#3C4A75] rounded-full flex items-center justify-center">
-                        <span className="text-white text-sm font-bold">🎯</span>
-                      </div>
-                      <span className="text-gray-700 font-medium">
-                        Consultoria gratuita
-                      </span>
-                    </motion.div>
+                    {t.contactPage.hero.stats.map((stat, index) => (
+                      <motion.div
+                        key={index}
+                        initial={{ opacity: 0, scale: 0.8 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        transition={{ duration: 0.6, delay: 0.8 + index * 0.2 }}
+                        className="flex items-center gap-3"
+                      >
+                        <div
+                          className={`w-8 h-8 ${index === 0 ? "bg-[#4CAF50]" : index === 1 ? "bg-[#D86C1F]" : "bg-[#3C4A75]"} rounded-full flex items-center justify-center`}
+                        >
+                          <span className="text-white text-sm font-bold">
+                            {stat.icon}
+                          </span>
+                        </div>
+                        <span className="text-gray-700 font-medium">
+                          {stat.text}
+                        </span>
+                      </motion.div>
+                    ))}
                   </div>
                 </motion.div>
 

--- a/app/contato/page.tsx
+++ b/app/contato/page.tsx
@@ -223,7 +223,7 @@ export default function ContactPage() {
                 className="text-center mb-16"
               >
                 <h2 className="text-2xl md:text-3xl font-bold text-[#1F2E5C] mb-6">
-                  Escolha Como Prefere Falar Conosco
+                  {t.contactPage.contactMethods.title}
                 </h2>
                 <motion.div
                   initial={{ width: 0 }}
@@ -233,7 +233,7 @@ export default function ContactPage() {
                   className="h-1 bg-[#D86C1F] mx-auto mb-6"
                 />
                 <p className="text-lg text-gray-600 max-w-3xl mx-auto">
-                  Oferecemos múltiplos canais de atendimento para sua comodidade
+                  {t.contactPage.contactMethods.subtitle}
                 </p>
               </motion.div>
 

--- a/app/contato/page.tsx
+++ b/app/contato/page.tsx
@@ -125,9 +125,9 @@ export default function ContactPage() {
                   transition={{ duration: 0.8, delay: 0.4 }}
                   className="text-5xl md:text-6xl lg:text-7xl font-bold text-[#1F2E5C] leading-tight mb-6"
                 >
-                  {t.contactPage.hero.title.split("\n")[0]}
+                  {t.contactPage.hero.title}
                   <span className="block text-2xl md:text-3xl lg:text-4xl text-[#D86C1F] font-medium mt-4">
-                    {t.contactPage.hero.title.split("\n")[1]}
+                    {t.contactPage.hero.subtitle}
                   </span>
                 </motion.h1>
 

--- a/app/contato/page.tsx
+++ b/app/contato/page.tsx
@@ -3,6 +3,8 @@
 import { motion } from "framer-motion";
 import { PageLayout } from "@/components/PageLayout";
 import { SimpleContactForm } from "@/components/SimpleContactForm";
+import { useLanguage } from "@/hooks/use-language";
+import { translations } from "@/i18n/translations";
 
 // Variantes de animação para reutilização
 const fadeInUp = {

--- a/app/contato/page.tsx
+++ b/app/contato/page.tsx
@@ -180,7 +180,7 @@ export default function ContactPage() {
                     whileTap={{ scale: 0.98 }}
                     className="inline-flex items-center gap-3 bg-gradient-to-r from-[#D86C1F] to-[#E1893D] hover:from-[#E1893D] hover:to-[#D86C1F] text-white px-10 py-5 rounded-2xl text-xl font-bold shadow-2xl hover:shadow-3xl transition-all duration-300"
                   >
-                    <span>Escolher Meu Canal Preferido</span>
+                    <span>{t.contactPage.hero.cta}</span>
                     <motion.span
                       animate={{ x: [0, 5, 0] }}
                       transition={{ duration: 1.5, repeat: Infinity }}
@@ -190,8 +190,7 @@ export default function ContactPage() {
                   </motion.a>
 
                   <p className="text-sm text-gray-500 max-w-md mx-auto">
-                    Ou role para baixo e descubra todas as formas de falar
-                    conosco
+                    {t.contactPage.hero.ctaDescription}
                     <span className="inline-block ml-1">👇</span>
                   </p>
                 </motion.div>

--- a/components/SimpleContactForm.tsx
+++ b/components/SimpleContactForm.tsx
@@ -22,6 +22,8 @@ type FormData = {
 };
 
 export function SimpleContactForm() {
+  const { language } = useLanguage();
+  const t = translations[language];
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const formSchema = z.object({

--- a/components/SimpleContactForm.tsx
+++ b/components/SimpleContactForm.tsx
@@ -11,6 +11,8 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Send } from "lucide-react";
+import { useLanguage } from "@/hooks/use-language";
+import { translations } from "@/i18n/translations";
 
 type FormData = {
   name: string;

--- a/i18n/en-US/en.ts
+++ b/i18n/en-US/en.ts
@@ -1106,10 +1106,10 @@ export const en = {
     title: "Contact",
     subtitle: "We're here to help you take the first step",
     hero: {
-      title: "Speak with Our Specialists",
-      badge: "Guaranteed response within 24 hours",
+      title: "Let's Talk?",
+      badge: "WE'RE ONLINE AND READY TO HELP",
       subtitle:
-        "We're ready to help you recover your credit. Personalized service and free initial consultation.",
+        "Our team of specialists is waiting for you! Let's discover together how to transform your credit situation into a success story.",
     },
     contactMethods: {
       title: "Choose How You Prefer to Contact Us",

--- a/i18n/en-US/en.ts
+++ b/i18n/en-US/en.ts
@@ -1110,6 +1110,13 @@ export const en = {
       badge: "WE'RE ONLINE AND READY TO HELP",
       subtitle:
         "Our team of specialists is waiting for you! Let's discover together how to transform your credit situation into a success story.",
+      stats: [
+        { icon: "✓", text: "24h Response" },
+        { icon: "💬", text: "Personalized Service" },
+        { icon: "🎯", text: "Free Consultation" },
+      ],
+      cta: "Choose My Preferred Channel",
+      ctaDescription: "Or scroll down and discover all the ways to contact us",
     },
     contactMethods: {
       title: "Choose How You Prefer to Contact Us",

--- a/i18n/pt-BR/pt.ts
+++ b/i18n/pt-BR/pt.ts
@@ -1133,10 +1133,18 @@ export const pt = {
     title: "Contato",
     subtitle: "Estamos aqui para ajudar você a dar o primeiro passo",
     hero: {
-      title: "Fale com Nossos Especialistas",
-      badge: "Resposta garantida em até 24 horas",
+      title: "Vamos Conversar?",
+      badge: "ESTAMOS ONLINE E PRONTOS PARA AJUDAR",
       subtitle:
-        "Estamos prontos para ajudar você a recuperar seu crédito. Atendimento personalizado e consulta inicial gratuita.",
+        "Nosso time de especialistas está esperando por você! Vamos descobrir juntos como transformar sua situação de crédito em uma história de sucesso.",
+      stats: [
+        { icon: "✓", text: "Resposta em 24h" },
+        { icon: "💬", text: "Atendimento humanizado" },
+        { icon: "🎯", text: "Consultoria gratuita" },
+      ],
+      cta: "Escolher Meu Canal Preferido",
+      ctaDescription:
+        "Ou role para baixo e descubra todas as formas de falar conosco",
     },
     contactMethods: {
       title: "Escolha Como Prefere Falar Conosco",


### PR DESCRIPTION
This pull request adds internationalization support to the contact page hero section by:

- Importing useLanguage hook and translations in ContactPage component
- Replacing hardcoded Portuguese text with translation keys for:
  - Hero badge text
  - Hero title and subtitle
  - Stats section (response time, personalized service, free consultation)
  - Call-to-action button text
  - CTA description text
  - Contact methods title and subtitle

- Adding useLanguage hook and translations imports to SimpleContactForm component

- Updating translation files (pt.ts and en.ts) with new contact page hero section keys:
  - Updated hero.title, hero.badge, and hero.subtitle
  - Added hero.stats array with icon and text properties
  - Added hero.cta and hero.ctaDescription keys

The changes convert static Portuguese text to dynamic content that supports both Portuguese and English languages through the existing translation system.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7d7e619705284187823c091f9c13a377/quantum-hub)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7d7e619705284187823c091f9c13a377</projectId>-->
<!--<branchName>quantum-hub</branchName>-->